### PR TITLE
Speaker volume too low, less than half the original ROM

### DIFF
--- a/configs/tiny_hw.xml
+++ b/configs/tiny_hw.xml
@@ -141,7 +141,7 @@ We are able to have most of our routing static so do that
         <ctl name="SPKR DAC1 Volume" val="1"/>
         <ctl name="Speaker Mixer Volume" val="3"/>
         <ctl name="Speaker Boost Volume" val="4"/>
-        <ctl name="Speaker Volume" val="57"/>
+        <ctl name="Speaker Volume" val="63"/>
     </path>
     <path name="off">
         <ctl name="SPK Switch" val="0"/>


### PR DESCRIPTION
The volume in speaker is too low. I've managed to rise it up by editing `/etc/sound/m0` file near line 144 where it reads 57 to 63. Now the volume is normal and at maximum it doesn't chop.

The problem is that the volume is overwritten after each update. This commit makes it permanent part of the build.
